### PR TITLE
Pin roctracer and base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN cd /packages && dpkg -i rocblas_2.45.0.50300-63.20.04_amd64.deb && \
 
 # Build roctracer required for pytorch
 RUN python -m pip install CppHeaderParser argparse && \
-    git clone -b amd-master https://github.com/ROCm-Developer-Tools/roctracer --depth 1 && \
+    git clone -b rocm-5.3.0 https://github.com/ROCm-Developer-Tools/roctracer --depth 1 && \
     mkdir roctracer/build && \
     cd roctracer/build && cmake -DCMAKE_INSTALL_PREFIX=/opt/rocm .. && make -j8 && make install && \
     cd ../../ && rm -rf ./environ && rm -rf roctracer

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/rocm/pytorch
+FROM docker.io/rocm/pytorch:rocm5.3_ubuntu20.04_py3.7_pytorch_staging
 
 # Set env var for gfx803 
 ENV ROC_ENABLE_PRE_VEGA=1


### PR DESCRIPTION
Because things on the Internet had changed (AMD merged rocm 5.3.1 into roctracer), I was not able to build the image with:

```
docker build -t rocm-pytorch-gfx803 https://github.com/Firstbober/rocm-pytorch-gfx803-docker.git#cc8925dbae689edc7dc3b61fde2f534893bafed4
```

These are the Dockerfile changes I had to make to make the image build, and to pin things so it shouldn't break again.